### PR TITLE
For #6 - set featured image on create new post

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -156,6 +156,13 @@ $scripts_js  = postbot_bundled_javascript();
 								</label>
 							</div>
 
+							<div id="featured-image">
+								<label>
+									<input type="checkbox" name="featured_image"/>
+									<?php _e( 'Set Featured Image' ); ?>
+								</label>
+							</div>
+
 						</div>
 
 					</div>

--- a/public_html/js/postbot.js
+++ b/public_html/js/postbot.js
@@ -160,6 +160,7 @@ function schedule_changed() {
 		data.minute         = parseInt( $( 'input[name=schedule_time_minute]').val(), 10 );
 		data.interval       = parseInt( $( 'select[name=schedule_interval]' ).val(), 10 );
 		data.ignore_weekend = $( 'input[name=ignore_weekend]' ).is( ':checked' ) ? 1 : 0;
+		data.featured_image = $( 'input[name=featured_image]' ).is( ':checked' ) ? 1 : 0;
 	}
 
 	$.post( postbot.ajax_url, data, function( response ) {
@@ -298,6 +299,7 @@ function setup_uploader() {
 			data.minute         = parseInt( $( 'input[name=schedule_time_minute]').val(), 10 );
 			data.interval       = parseInt( $( 'select[name=schedule_interval]' ).val(), 10 );
 			data.ignore_weekend = $( 'input[name=ignore_weekend]' ).is( ':checked' ) ? 1 : 0;
+			data.featured_image = $( 'input[name=featured_image]' ).is( ':checked' ) ? 1 : 0;
 		}
 
 		disable_form_elements( true );


### PR DESCRIPTION
For #6 - set featured image on create new post

This does an extra call to set the featured_image to the attachment id of uploaded attachment. 
An extra call is needed because the featured_image is set to the post id of the attachment which is not known until after the upload.

We may want a setting somewhere whether or not to set the featured_image, this will make it down by default which should not cause any issues even if a theme doesn't support it since it won't do anything with the info. 

The only concern would be for themes that might duplicate the image showing both the content and the featured image.
